### PR TITLE
Fix for junk after request

### DIFF
--- a/src/libs/ws/server.rs
+++ b/src/libs/ws/server.rs
@@ -134,7 +134,7 @@ impl WebsocketServer {
         tracing::debug!("Raw request bytes: {:?}", &buffer[..n]);
 
         let stream = BufferedStream {
-            buffer: buffer.into_boxed_slice(),
+            buffer: buffer[..n].to_vec().into_boxed_slice(),
             stream,
             pos: 0,
         };


### PR DESCRIPTION
`buffer: vec![0u8; 1024]` is filled with zeroes and `into_boxed_slice` keeps them. I cut the data only for the length we need