### PR TITLE
Disable ansi logging for files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "endpoint-libs"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2021"
 authors = ["Veon <dveonloch@protonmail.com>"]
 description = "Common dependencies to be used with endpoint-gen."


### PR DESCRIPTION
* add `.with_ansi(false)` for file logging 
* `less` command does not recognize ansi logs