### PR TITLE
perf: Removed needless Arc::clone on role check

### DIFF
--- a/src/libs/ws/session.rs
+++ b/src/libs/ws/session.rs
@@ -111,7 +111,7 @@ impl<
             return Ok(true);
         };
 
-        let allowed = check_roles(context.roles.clone(), allowed_roles);
+        let allowed = check_roles(&context.roles, allowed_roles);
         if !allowed {
             self.server.toolbox.send(
                 context.connection_id,
@@ -192,7 +192,7 @@ impl<
     }
 }
 
-fn check_roles(actual_roles: Arc<Vec<u32>>, allowed_roles: &HashSet<u32>) -> bool {
+fn check_roles(actual_roles: &[u32], allowed_roles: &HashSet<u32>) -> bool {
     if allowed_roles.is_empty() {
         return false; // No roles are allowed
     }
@@ -206,20 +206,18 @@ fn check_roles(actual_roles: Arc<Vec<u32>>, allowed_roles: &HashSet<u32>) -> boo
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     #[test]
     fn check_roles_allowed() {
         use super::check_roles;
         use std::collections::HashSet;
 
         let allowed_roles: HashSet<u32> = [1, 2, 3].iter().cloned().collect();
-        assert!(check_roles(Arc::new(vec![1]), &allowed_roles.clone()));
-        assert!(check_roles(Arc::new(vec![2]), &allowed_roles.clone()));
-        assert!(check_roles(Arc::new(vec![1, 2]), &allowed_roles.clone()));
-        assert!(check_roles(Arc::new(vec![4, 2]), &allowed_roles.clone()));
+        assert!(check_roles(&[1], &allowed_roles.clone()));
+        assert!(check_roles(&[2], &allowed_roles.clone()));
+        assert!(check_roles(&[1, 2], &allowed_roles.clone()));
+        assert!(check_roles(&[4, 2], &allowed_roles.clone()));
 
-        assert!(!check_roles(Arc::new(vec![4]), &allowed_roles.clone()));
+        assert!(!check_roles(&[4], &allowed_roles.clone()));
     }
 
     #[test]
@@ -228,6 +226,6 @@ mod tests {
         use std::collections::HashSet;
 
         let allowed_roles: HashSet<u32> = HashSet::new();
-        assert!(!check_roles(Arc::new(vec![1]), &allowed_roles));
+        assert!(!check_roles(&[1], &allowed_roles));
     }
 }


### PR DESCRIPTION
Since the roles for the current request context are cloned on line 107, there's no need to increase the reference counter once again to check them. The data is already present and accessing it is totally safe.