### PR TITLE
feat: Added well-known error codes as consts

### DIFF
--- a/src/libs/error_code.rs
+++ b/src/libs/error_code.rs
@@ -8,19 +8,31 @@ pub struct ErrorCode {
 }
 
 impl ErrorCode {
+    /// Indicated a bad request.
+    pub const BAD_REQUEST: Self = Self::new(100400);
+
+    /// Indicates forbidden access.
+    pub const FORBIDDEN: Self = Self::new(100403);
+
+    /// Indicates an internal server error.
+    pub const INTERNAL_ERROR: Self = Self::new(100500);
+
+    /// Indicates a non-implemented endpoint.
+    pub const NOT_IMPLEMENTED: Self = Self::new(100501);
+
     /// Create a new `ErrorCode` from a `u32`.
-    pub fn new(code: u32) -> Self {
+    pub const fn new(code: u32) -> Self {
         Self { code }
     }
 
     /// Get the `ErrorCode` as a `u32`.
     /// Just returns the code field.
-    pub fn to_u32(self) -> u32 {
+    pub const fn to_u32(self) -> u32 {
         self.code
     }
 
     /// Getter for the `ErrorCode` code field.
-    pub fn code(self) -> u32 {
+    pub const fn code(self) -> u32 {
         self.to_u32()
     }
 }

--- a/src/libs/handler.rs
+++ b/src/libs/handler.rs
@@ -38,7 +38,7 @@ impl<T: RequestHandler> RequestHandlerErased for T {
                     ctx.connection_id,
                     request_error_to_resp(
                         &ctx,
-                        ErrorCode::new(100400), // Bad Request
+                        ErrorCode::BAD_REQUEST,
                         if let Some(path) = path {
                             format!("{path}: {err}")
                         } else {

--- a/src/libs/toolbox.rs
+++ b/src/libs/toolbox.rs
@@ -197,11 +197,7 @@ impl Toolbox {
                 let err = err.downcast::<CustomError>().unwrap();
                 request_error_to_resp(&ctx, err.code, err.params)
             }
-            Err(err) => internal_error_to_resp(
-                &ctx,
-                ErrorCode::new(100500), // Internal Error
-                err,
-            ),
+            Err(err) => internal_error_to_resp(&ctx, ErrorCode::INTERNAL_ERROR, err),
         };
         Some(resp)
     }

--- a/src/libs/ws/server.rs
+++ b/src/libs/ws/server.rs
@@ -186,7 +186,7 @@ impl WebsocketServer {
         if let Err(err) = auth_result {
             self.toolbox.send_request_error(
                 &raw_ctx,
-                ErrorCode::new(100400), // BadRequest
+                ErrorCode::BAD_REQUEST,
                 err.to_string(),
             );
             return Err(err);

--- a/src/libs/ws/server.rs
+++ b/src/libs/ws/server.rs
@@ -184,11 +184,8 @@ impl WebsocketServer {
             .await;
         let raw_ctx = RequestContext::from_conn(&conn);
         if let Err(err) = auth_result {
-            self.toolbox.send_request_error(
-                &raw_ctx,
-                ErrorCode::BAD_REQUEST,
-                err.to_string(),
-            );
+            self.toolbox
+                .send_request_error(&raw_ctx, ErrorCode::BAD_REQUEST, err.to_string());
             return Err(err);
         }
         self.handle_session_connection(conn, states, stream, rx)

--- a/src/libs/ws/session.rs
+++ b/src/libs/ws/session.rs
@@ -92,11 +92,7 @@ impl<
             Err(err) => {
                 self.server.toolbox.send(
                     context.connection_id,
-                    request_error_to_resp(
-                        &context,
-                        ErrorCode::new(100400), // BadRequest
-                        err.to_string(),
-                    ),
+                    request_error_to_resp(&context, ErrorCode::BAD_REQUEST, err.to_string()),
                 );
                 return Ok(true);
             }
@@ -115,11 +111,7 @@ impl<
         if !allowed {
             self.server.toolbox.send(
                 context.connection_id,
-                request_error_to_resp(
-                    &context,
-                    ErrorCode::new(100403), // Forbidden
-                    "Forbidden",
-                ),
+                request_error_to_resp(&context, ErrorCode::FORBIDDEN, "Forbidden"),
             );
             return Ok(true);
         }
@@ -130,11 +122,7 @@ impl<
             None => {
                 self.server.toolbox.send(
                     context.connection_id,
-                    request_error_to_resp(
-                        &context,
-                        ErrorCode::new(100501), // Not Implemented
-                        Value::Null,
-                    ),
+                    request_error_to_resp(&context, ErrorCode::NOT_IMPLEMENTED, Value::Null),
                 );
                 return Ok(true);
             }


### PR DESCRIPTION
It's easier to reference an existing value than copy-past some code and leave a comment near it telling what it's for.