### PR TITLE
feat: Replaced alloy by alloy_primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,5 @@ lazy_static = "1.5"
 tokio-util = "0.7"
 hyper-util = {version = "0.1", features = ["full"]}
 rev_lines = "0.3"
-alloy = { version = "0.5", features = ["full"] }
 tempfile = "3.19.0"
+alloy-primitives = { version = "1.3.0", features = ["std"], default-features = false }

--- a/src/libs/types.rs
+++ b/src/libs/types.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 use std::ops::{Deref, DerefMut};
 
 #[doc(hidden)]
-pub use alloy::primitives::{Address, B256 as H256, U256};
+pub use alloy_primitives::{Address, B256 as H256, U256};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 


### PR DESCRIPTION
The previously linked `alloy` version is outdated and moreover it had full feature set while only minimal is required. Therefore, `alloy_primitives` is the right choice.