### PR TITLE
feat(ws): wire opt-in MCP surface into the WebSocket server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,6 +203,10 @@ rcgen = "0.14"
 cert-provider = {git = "https://github.com/dVeon-loch/cert-provider.git", features = ["dns01"]}
 
 [[example]]
+name = "mcp_echo"
+required-features = ["ws-http1"]
+
+[[example]]
 name = "ws_echo_rustls"
 required-features = ["ws"]
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The crate is feature-gated. The default feature set is `types` only.
 Endpoint schema types shared between services and `endpoint-gen`:
 
 - `Type`, `Field`, `EnumVariant` — the type system used to describe endpoint request/response schemas
+- `TypeRegistry` and `Type::to_json_schema` — conversion of endpoint schemas to JSON Schema (used for MCP tool definitions, see below)
 - Blockchain primitive types: `BlockchainAddress`, `BlockchainTransactionHash`, `U256`, `H256`
 
 ### `ws`
@@ -113,6 +114,64 @@ impl SubAuthController for MethodSignup {
         .boxed_local()
     }
 }
+```
+
+### MCP (Model Context Protocol) support
+
+The WebSocket server can optionally expose every registered endpoint as an
+**MCP tool** over JSON-RPC 2.0, alongside the legacy `{method, seq, params}`
+protocol. MCP is **off by default** and fully additive: with it disabled the
+server behaves exactly as before, and even with it enabled, legacy frames are
+routed unchanged — both protocols work on the same connection.
+
+Supported MCP methods: `initialize`, `ping`, `tools/list` (filtered by the
+connection's roles), `tools/call`, and `notifications/*`. Tool metadata
+(`inputSchema` / `outputSchema`) is generated from the endpoint schemas via
+`Type::to_json_schema` (`model::json_schema`, available under the default
+`types` feature).
+
+```rust
+use endpoint_libs::libs::ws::mcp::McpServerInfo;
+use endpoint_libs::model::TypeRegistry;
+
+let mut server = WebsocketServer::new(config);
+server.set_auth_controller(MyAuthController);
+server.add_handler(MethodEcho);
+// ... all other add_handler() calls ...
+
+// With endpoint-gen generated code, use the generated `type_registry()`.
+// Endpoints that only use primitive types can pass an empty registry.
+let registry: TypeRegistry = type_registry();
+server.enable_mcp(
+    &registry,
+    McpServerInfo { name: "my-service".into(), version: env!("CARGO_PKG_VERSION").into() },
+)?;
+
+server.listen().await
+```
+
+Behavior notes:
+
+- **Frame detection** — a frame is treated as JSON-RPC iff it carries a
+  top-level `"jsonrpc": "2.0"` member, which legacy frames can never contain.
+- **Tool names** — endpoint names in snake_case (`UserListSymbols` →
+  `user_list_symbols`).
+- **Roles** — `tools/list` only shows tools the connection's roles allow;
+  calling a forbidden tool answers identically to an unknown tool.
+- **Errors** — public handler errors (`CustomError`) become MCP tool results
+  with `isError: true`; invalid params map to `-32602`, unknown methods to
+  `-32601`, internal errors to `-32603` (with `logId` in `error.data`).
+- **Streaming** — endpoints with a `stream_response` deliver only their
+  immediate response over MCP; stream frames are not forwarded (tools are
+  annotated accordingly in their description).
+- `enable_mcp` fails at startup on unresolved `StructRef`/`EnumRef` names or
+  duplicate tool names, rather than serving broken schemas.
+
+A runnable end-to-end example (MCP handshake + legacy frame on one
+connection) is provided:
+
+```sh
+cargo run --example mcp_echo --features ws-http1
 ```
 
 ### `signal`

--- a/examples/mcp_echo.rs
+++ b/examples/mcp_echo.rs
@@ -1,0 +1,305 @@
+//! MCP echo example and end-to-end check.
+//!
+//! Starts a WebSocket server with a single `Echo` endpoint and the MCP surface
+//! enabled, then connects a client and exercises both protocols on the same
+//! connection:
+//!
+//! 1. MCP: `initialize` → `notifications/initialized` → `tools/list` →
+//!    `tools/call` (`echo`)
+//! 2. Legacy: a `{method, seq, params}` frame, verifying the pre-existing
+//!    protocol still works unchanged next to MCP.
+//!
+//! Run with:
+//! ```sh
+//! cargo run --example mcp_echo --features ws-http1
+//! ```
+//! The process asserts on every response and exits 0 on success.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use endpoint_libs::libs::handler::{RequestHandler, Response};
+use endpoint_libs::libs::log::{LogLevel, LoggingConfig, OtelConfig, setup_logging};
+use endpoint_libs::libs::toolbox::{ArcToolbox, RequestContext};
+use endpoint_libs::libs::ws::mcp::McpServerInfo;
+use endpoint_libs::libs::ws::toolbox::CustomError;
+use endpoint_libs::libs::ws::{
+    AuthController, WebsocketServer, WsConnection, WsRequest, WsResponse, WsServerConfig,
+};
+use endpoint_libs::model::TypeRegistry;
+use eyre::{Result, bail};
+use futures::future::LocalBoxFuture;
+use futures::{FutureExt, SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use tokio_tungstenite::tungstenite::Message;
+
+const ADDR: &str = "127.0.0.1:8899";
+
+// --- Echo endpoint (same conventions as the ws-echo example) ---
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EchoRequest {
+    pub message: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EchoResponse {
+    pub message: String,
+}
+
+impl WsRequest for EchoRequest {
+    type Response = EchoResponse;
+    const METHOD_ID: u32 = 1;
+    const ROLES: &'static [u32] = &[1];
+    const SCHEMA: &'static str = r#"{
+        "name":        "Echo",
+        "code":        1,
+        "parameters":  [{"name": "message", "ty": "String"}],
+        "returns":     [{"name": "message", "ty": "String"}],
+        "description": "Echoes the message back.",
+        "roles":       []
+    }"#;
+}
+
+impl WsResponse for EchoResponse {
+    type Request = EchoRequest;
+}
+
+pub struct MethodEcho;
+
+#[async_trait(?Send)]
+impl RequestHandler for MethodEcho {
+    type Request = EchoRequest;
+    type Error = CustomError;
+
+    async fn handle(&self, _ctx: RequestContext, req: EchoRequest) -> Response<EchoRequest> {
+        Ok(EchoResponse {
+            message: format!("echo: {}", req.message),
+        })
+    }
+}
+
+// --- Allow-all auth: grants role 1 so the Echo tool is visible/callable ---
+
+struct AllowAllAuthController;
+
+impl AuthController for AllowAllAuthController {
+    fn auth(
+        self: Arc<Self>,
+        _toolbox: &ArcToolbox,
+        _header: String,
+        conn: Arc<WsConnection>,
+    ) -> LocalBoxFuture<'static, Result<()>> {
+        async move {
+            conn.set_roles(Arc::new(vec![1]));
+            Ok(())
+        }
+        .boxed_local()
+    }
+}
+
+// --- Client helpers ---
+
+type WsClient =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn send_json(ws: &mut WsClient, frame: Value) -> Result<()> {
+    ws.send(Message::Text(frame.to_string().into())).await?;
+    Ok(())
+}
+
+async fn recv_json(ws: &mut WsClient) -> Result<Value> {
+    loop {
+        let Some(msg) = ws.next().await else {
+            bail!("connection closed while waiting for a response");
+        };
+        match msg? {
+            Message::Text(t) => return Ok(serde_json::from_str(&t)?),
+            Message::Binary(b) => return Ok(serde_json::from_slice(&b)?),
+            Message::Ping(_) | Message::Pong(_) => continue,
+            other => bail!("unexpected frame: {other:?}"),
+        }
+    }
+}
+
+fn expect(cond: bool, what: &str) -> Result<()> {
+    if cond {
+        println!("ok: {what}");
+        Ok(())
+    } else {
+        bail!("FAILED: {what}");
+    }
+}
+
+async fn run_client() -> Result<()> {
+    let (mut ws, _) = tokio_tungstenite::connect_async(format!("ws://{ADDR}")).await?;
+
+    // 1. initialize
+    send_json(
+        &mut ws,
+        json!({"jsonrpc": "2.0", "id": 0, "method": "initialize", "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "mcp-echo-client", "version": "0.0.0"},
+        }}),
+    )
+    .await?;
+    let resp = recv_json(&mut ws).await?;
+    expect(resp["id"] == json!(0), "initialize: id echoed")?;
+    expect(
+        resp["result"]["serverInfo"]["name"] == json!("mcp-echo"),
+        "initialize: serverInfo.name",
+    )?;
+    expect(
+        resp["result"]["capabilities"]["tools"].is_object(),
+        "initialize: tools capability",
+    )?;
+
+    // 2. notifications/initialized — a notification, must produce no response
+    send_json(
+        &mut ws,
+        json!({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+    )
+    .await?;
+
+    // 3. tools/list
+    send_json(
+        &mut ws,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+    )
+    .await?;
+    let resp = recv_json(&mut ws).await?;
+    let tools = resp["result"]["tools"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    expect(tools.len() == 1, "tools/list: one tool")?;
+    expect(tools[0]["name"] == json!("echo"), "tools/list: tool name")?;
+    expect(
+        tools[0]["inputSchema"]["required"] == json!(["message"]),
+        "tools/list: inputSchema.required",
+    )?;
+
+    // 4. tools/call
+    send_json(
+        &mut ws,
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {
+            "name": "echo",
+            "arguments": {"message": "hello mcp"},
+        }}),
+    )
+    .await?;
+    let resp = recv_json(&mut ws).await?;
+    expect(resp["id"] == json!(2), "tools/call: id echoed")?;
+    expect(
+        resp["result"]["isError"] == json!(false),
+        "tools/call: not an error",
+    )?;
+    expect(
+        resp["result"]["structuredContent"]["message"] == json!("echo: hello mcp"),
+        "tools/call: structuredContent",
+    )?;
+
+    // 5. tools/call with bad arguments → JSON-RPC invalid params (-32602)
+    send_json(
+        &mut ws,
+        json!({"jsonrpc": "2.0", "id": 3, "method": "tools/call", "params": {
+            "name": "echo",
+            "arguments": {"message": 42},
+        }}),
+    )
+    .await?;
+    let resp = recv_json(&mut ws).await?;
+    expect(
+        resp["error"]["code"] == json!(-32602),
+        "tools/call: invalid params -> -32602",
+    )?;
+
+    // 6. Legacy protocol on the same connection — must be unaffected by MCP.
+    send_json(
+        &mut ws,
+        json!({"method": 1, "seq": 42, "params": {"message": "legacy"}}),
+    )
+    .await?;
+    let resp = recv_json(&mut ws).await?;
+    expect(
+        resp["type"] == json!("Immediate"),
+        "legacy: Immediate response",
+    )?;
+    expect(resp["seq"] == json!(42), "legacy: seq echoed")?;
+    expect(
+        resp["params"]["message"] == json!("echo: legacy"),
+        "legacy: echo payload",
+    )?;
+
+    ws.close(None).await.ok();
+    Ok(())
+}
+
+// --- Entry point ---
+
+fn main() -> Result<()> {
+    let _log = setup_logging(LoggingConfig {
+        level: LogLevel::Info,
+        otel_config: OtelConfig::default(),
+        file_config: None,
+        #[cfg(feature = "error_aggregation")]
+        error_aggregation: Default::default(),
+        #[cfg(feature = "log_throttling")]
+        throttling_config: None,
+    })?;
+
+    // Server on its own runtime/thread; listen() runs until killed.
+    std::thread::spawn(|| {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("server runtime");
+        rt.block_on(async {
+            let config = WsServerConfig {
+                name: "mcp-echo".to_string(),
+                address: ADDR.to_string(),
+                insecure: true,
+                ..Default::default()
+            };
+            let mut server = WebsocketServer::new(config);
+            server.set_auth_controller(AllowAllAuthController);
+            server.add_handler(MethodEcho);
+
+            // The Echo endpoint only uses primitives, so an empty registry
+            // suffices; endpoints with StructRef/EnumRef parameters register
+            // their referenced types here.
+            let registry = TypeRegistry::new();
+            server
+                .enable_mcp(
+                    &registry,
+                    McpServerInfo {
+                        name: "mcp-echo".into(),
+                        version: env!("CARGO_PKG_VERSION").into(),
+                    },
+                )
+                .expect("enable_mcp");
+
+            server.listen().await.expect("server listen");
+        });
+    });
+
+    // Client on the main runtime.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        // Wait for the server to come up.
+        for _ in 0..50 {
+            if tokio::net::TcpStream::connect(ADDR).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        run_client().await
+    })?;
+
+    println!("all checks passed");
+    std::process::exit(0);
+}

--- a/src/libs/ws.rs
+++ b/src/libs/ws.rs
@@ -3,6 +3,7 @@ mod conn;
 pub mod handler;
 mod headers;
 mod listener;
+pub mod mcp;
 mod message;
 mod push;
 mod server;

--- a/src/libs/ws/handler.rs
+++ b/src/libs/ws/handler.rs
@@ -4,7 +4,13 @@ use serde_json::Value;
 use crate::libs::{
     error_code::ErrorCode,
     toolbox::{ArcToolbox, CustomError, RequestContext, Toolbox},
-    ws::{WsRequest, WsResponseError, WsResponseValue},
+    ws::{
+        WsRequest, WsResponseError, WsResponseValue,
+        mcp::{
+            self, JsonRpcError, McpCallCtx, encode_tool_error, encode_tool_result,
+            error_code_to_jsonrpc, jsonrpc_error, jsonrpc_result,
+        },
+    },
 };
 
 #[allow(type_alias_bounds)]
@@ -62,6 +68,30 @@ pub trait RequestHandler: Send + Sync {
 #[async_trait(?Send)]
 pub trait RequestHandlerErased: Send + Sync {
     async fn handle(&self, toolbox: &ArcToolbox, ctx: RequestContext, req: Value);
+
+    /// MCP `tools/call` entry point: same deserialization and handler
+    /// dispatch as [`Self::handle`], but the response is encoded as a
+    /// JSON-RPC/MCP frame addressed to `mcp.id`.
+    ///
+    /// The default body keeps manual `RequestHandlerErased` impls
+    /// source-compatible; the blanket impl for [`RequestHandler`] overrides it.
+    async fn handle_mcp(
+        &self,
+        toolbox: &ArcToolbox,
+        ctx: RequestContext,
+        mcp: McpCallCtx,
+        req: Value,
+    ) {
+        let _ = req;
+        toolbox.send_raw(
+            ctx.connection_id,
+            jsonrpc_error(
+                &mcp.id,
+                JsonRpcError::new(mcp::METHOD_NOT_FOUND, "Handler does not support MCP"),
+            )
+            .to_string(),
+        );
+    }
 }
 
 #[async_trait(?Send)]
@@ -105,5 +135,90 @@ impl<T: RequestHandler> RequestHandlerErased for T {
         {
             toolbox.send(ctx.connection_id, resp);
         }
+    }
+
+    async fn handle_mcp(
+        &self,
+        toolbox: &ArcToolbox,
+        ctx: RequestContext,
+        mcp: McpCallCtx,
+        req: Value,
+    ) {
+        let data: T::Request = match serde_json::from_value(req.clone()) {
+            Ok(data) => data,
+            Err(err) => {
+                // Re-run through serde_path_to_error for a field-path message,
+                // mirroring the legacy handle() diagnostics.
+                let buf = serde_json::to_string(&req).unwrap_or_default();
+                let jd = &mut serde_json::Deserializer::from_str(&buf);
+                let data: std::result::Result<T::Request, _> = serde_path_to_error::deserialize(jd);
+                let message = match data.err().map(|err| err.path().to_string()) {
+                    Some(path) => format!("{path}: {err}"),
+                    None => format!("{err}"),
+                };
+                toolbox.send_raw(
+                    ctx.connection_id,
+                    jsonrpc_error(
+                        &mcp.id,
+                        JsonRpcError::new(
+                            mcp::INVALID_PARAMS,
+                            format!("Invalid params: {message}"),
+                        ),
+                    )
+                    .to_string(),
+                );
+                return;
+            }
+        };
+
+        let resp = RequestHandler::handle(self, ctx.clone(), data).await;
+        let frame = match resp {
+            Ok(ok) => match serde_json::to_value(&ok) {
+                Ok(value) => jsonrpc_result(&mcp.id, encode_tool_result(&value)),
+                Err(err) => {
+                    tracing::error!(
+                        ws_server = true,
+                        conn_id = ctx.connection_id,
+                        err = %err,
+                        "Failed to serialize MCP response — sending error to client"
+                    );
+                    jsonrpc_error(
+                        &mcp.id,
+                        error_code_to_jsonrpc(
+                            ErrorCode::INTERNAL_ERROR,
+                            serde_json::json!({ "logId": ctx.log_id.to_string() }),
+                        ),
+                    )
+                }
+            },
+            // Public errors are tool-level failures: isError:true results.
+            Err(HandlerError::Public(err)) => {
+                let err: CustomError = err.into();
+                tracing::warn!(
+                    ws_server = true,
+                    conn_id = ctx.connection_id,
+                    "MCP request error: {:?}",
+                    err
+                );
+                jsonrpc_result(&mcp.id, encode_tool_error(err.code, &err.params))
+            }
+            Err(HandlerError::Internal(err)) => {
+                tracing::error!(
+                    ws_server = true,
+                    conn_id = ctx.connection_id,
+                    "MCP internal error: {:?}",
+                    err
+                );
+                jsonrpc_error(
+                    &mcp.id,
+                    error_code_to_jsonrpc(
+                        ErrorCode::INTERNAL_ERROR,
+                        serde_json::json!({ "logId": ctx.log_id.to_string() }),
+                    ),
+                )
+            }
+            Err(HandlerError::NoResponse) => return,
+        };
+        toolbox.send_raw(ctx.connection_id, frame.to_string());
     }
 }

--- a/src/libs/ws/mcp.rs
+++ b/src/libs/ws/mcp.rs
@@ -1,0 +1,668 @@
+//! JSON-RPC 2.0 envelope and MCP (Model Context Protocol) server surface.
+//!
+//! This module is purely additive: it defines the JSON-RPC message types, the
+//! mapping from application [`ErrorCode`]s to JSON-RPC errors, and
+//! [`McpState`] — precomputed MCP tool metadata built from the registered
+//! endpoint handlers. The legacy `{method, seq, params}` protocol is untouched;
+//! routing between the two lives in the session layer.
+//!
+//! MCP methods handled here: `initialize`, `ping`, `tools/list`,
+//! `notifications/*` (ignored). `tools/call` is resolved to a
+//! [`McpAction::ToolCall`] for the session layer to dispatch to the endpoint's
+//! request handler.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::libs::error_code::ErrorCode;
+use crate::libs::ws::WsEndpoint;
+use crate::model::TypeRegistry;
+
+/// MCP protocol revision implemented by this server.
+pub const MCP_PROTOCOL_VERSION: &str = "2025-06-18";
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 envelope
+// ---------------------------------------------------------------------------
+
+/// JSON-RPC reserved error codes.
+pub const PARSE_ERROR: i64 = -32700;
+pub const INVALID_REQUEST: i64 = -32600;
+pub const METHOD_NOT_FOUND: i64 = -32601;
+pub const INVALID_PARAMS: i64 = -32602;
+pub const INTERNAL_ERROR: i64 = -32603;
+
+/// A JSON-RPC request id: a number or a string.
+///
+/// A request without an id is a notification and receives no response. An
+/// explicit `"id": null` is treated the same way (only ever legal in *error
+/// responses* per spec, so conflating it costs nothing in practice).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum JsonRpcId {
+    Num(i64),
+    Str(String),
+}
+
+impl JsonRpcId {
+    fn to_value(id: &Option<JsonRpcId>) -> Value {
+        match id {
+            Some(JsonRpcId::Num(n)) => json!(n),
+            Some(JsonRpcId::Str(s)) => json!(s),
+            None => Value::Null,
+        }
+    }
+}
+
+/// Incoming JSON-RPC 2.0 request or notification.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    #[serde(default)]
+    pub id: Option<JsonRpcId>,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Value>,
+}
+
+impl JsonRpcRequest {
+    /// True when this request is a notification (no id → no response is sent).
+    pub fn is_notification(&self) -> bool {
+        self.id.is_none()
+    }
+}
+
+/// JSON-RPC error object.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<Value>,
+}
+
+impl JsonRpcError {
+    pub fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    pub fn with_data(mut self, data: Value) -> Self {
+        self.data = Some(data);
+        self
+    }
+}
+
+/// Serializes a JSON-RPC success response.
+pub fn jsonrpc_result(id: &Option<JsonRpcId>, result: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": JsonRpcId::to_value(id),
+        "result": result,
+    })
+}
+
+/// Serializes a JSON-RPC error response.
+pub fn jsonrpc_error(id: &Option<JsonRpcId>, error: JsonRpcError) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": JsonRpcId::to_value(id),
+        "error": error,
+    })
+}
+
+/// Detects and parses a JSON-RPC frame.
+///
+/// Returns `Some` iff the payload is a JSON object with a top-level
+/// `"jsonrpc": "2.0"` member — legacy `{method: u32, seq, params}` frames can
+/// never match, so detection is unambiguous. A frame that declares
+/// `"jsonrpc": "2.0"` but fails to parse as a request yields
+/// `Some(Err(error))` carrying the ready-to-send error response.
+pub fn try_parse_jsonrpc(payload: &str) -> Option<Result<JsonRpcRequest, Value>> {
+    let value: Value = serde_json::from_str(payload).ok()?;
+    if value.get("jsonrpc").and_then(Value::as_str) != Some("2.0") {
+        return None;
+    }
+    match serde_json::from_value::<JsonRpcRequest>(value) {
+        Ok(req) => Some(Ok(req)),
+        Err(err) => Some(Err(jsonrpc_error(
+            &None,
+            JsonRpcError::new(INVALID_REQUEST, format!("Invalid Request: {err}")),
+        ))),
+    }
+}
+
+/// Maps an application [`ErrorCode`] (100xxx) to a JSON-RPC error.
+///
+/// Codes with a reserved JSON-RPC equivalent are translated; all others pass
+/// through as positive application-domain codes. The original kind and code
+/// are preserved in `error.data`.
+pub fn error_code_to_jsonrpc(code: ErrorCode, data: Value) -> JsonRpcError {
+    let (rpc_code, message) = match code {
+        ErrorCode::BAD_REQUEST => (INVALID_PARAMS, "Invalid params"),
+        ErrorCode::NOT_IMPLEMENTED => (METHOD_NOT_FOUND, "Method not found"),
+        ErrorCode::INTERNAL_ERROR => (INTERNAL_ERROR, "Internal error"),
+        other => (other.to_u32() as i64, other.kind()),
+    };
+    let mut err = JsonRpcError::new(rpc_code, message);
+    let mut merged = json!({ "kind": code.kind(), "appCode": code.to_u32() });
+    if let (Value::Object(target), Value::Object(extra)) = (&mut merged, data) {
+        for (k, v) in extra {
+            target.insert(k, v);
+        }
+    }
+    err.data = Some(merged);
+    err
+}
+
+// ---------------------------------------------------------------------------
+// MCP tool result encoding
+// ---------------------------------------------------------------------------
+
+/// Wraps a successful handler response in the MCP `tools/call` result shape.
+pub fn encode_tool_result(response: &Value) -> Value {
+    json!({
+        "content": [{ "type": "text", "text": response.to_string() }],
+        "structuredContent": response,
+        "isError": false,
+    })
+}
+
+/// Wraps a public (expected) handler error in the MCP `tools/call` result
+/// shape. Per MCP, tool-level failures are results with `isError: true`, not
+/// protocol errors.
+pub fn encode_tool_error(code: ErrorCode, params: &Value) -> Value {
+    let message = params
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| code.kind());
+    json!({
+        "content": [{ "type": "text", "text": message }],
+        "structuredContent": {
+            "error": { "kind": code.kind(), "appCode": code.to_u32(), "params": params },
+        },
+        "isError": true,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// MCP server state
+// ---------------------------------------------------------------------------
+
+/// Server identity reported in the `initialize` result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct McpServerInfo {
+    pub name: String,
+    pub version: String,
+}
+
+/// Precomputed per-endpoint tool metadata, built once at startup.
+#[derive(Debug, Clone)]
+pub struct McpTool {
+    /// Tool name: the endpoint name in snake_case.
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+    pub output_schema: Option<Value>,
+    /// Key back into `WebsocketServer::handlers`.
+    pub method_code: u32,
+    pub allowed_roles: HashSet<u32>,
+    /// Endpoints with a stream response deliver only their immediate response
+    /// over MCP; stream frames are not forwarded.
+    pub streaming: bool,
+}
+
+impl McpTool {
+    fn to_list_entry(&self) -> Value {
+        let mut entry = json!({
+            "name": self.name,
+            "description": self.description,
+            "inputSchema": self.input_schema,
+        });
+        if let Some(output) = &self.output_schema {
+            entry["outputSchema"] = output.clone();
+        }
+        entry
+    }
+}
+
+/// The action the session layer should take for a routed JSON-RPC request.
+#[derive(Debug)]
+pub enum McpAction {
+    /// A ready-to-send response frame (already serialized to a JSON value).
+    Respond(Value),
+    /// Dispatch `tools/call` to the endpoint handler for `method_code`.
+    ToolCall {
+        id: Option<JsonRpcId>,
+        method_code: u32,
+        arguments: Value,
+    },
+    /// Nothing to do (notification).
+    Ignore,
+}
+
+/// Immutable MCP state attached to a [`WebsocketServer`] when MCP is enabled.
+///
+/// [`WebsocketServer`]: crate::libs::ws::WebsocketServer
+pub struct McpState {
+    pub tools: Vec<McpTool>,
+    pub by_name: HashMap<String, usize>,
+    pub info: McpServerInfo,
+    pub protocol_version: &'static str,
+}
+
+impl McpState {
+    /// Builds MCP tool metadata from the registered handlers.
+    ///
+    /// Fails on unresolved type references (see
+    /// [`Type::to_json_schema`](crate::model::Type::to_json_schema)) and on
+    /// duplicate tool names, so misconfiguration surfaces at startup.
+    pub fn build(
+        handlers: &HashMap<u32, WsEndpoint>,
+        registry: &TypeRegistry,
+        info: McpServerInfo,
+    ) -> eyre::Result<Self> {
+        let mut tools = Vec::with_capacity(handlers.len());
+        let mut by_name = HashMap::with_capacity(handlers.len());
+
+        // Sort by code for a deterministic tools/list order.
+        let mut endpoints: Vec<&WsEndpoint> = handlers.values().collect();
+        endpoints.sort_by_key(|e| e.schema.code);
+
+        for endpoint in endpoints {
+            let schema = &endpoint.schema;
+            let name = schema.tool_name();
+            let streaming = schema.stream_response.is_some();
+
+            let mut description = schema.description.clone();
+            if streaming {
+                if !description.is_empty() {
+                    description.push(' ');
+                }
+                description
+                    .push_str("(Streaming endpoint: stream frames are not delivered over MCP.)");
+            }
+
+            let input_schema = schema.to_mcp_input_schema(registry)?;
+            let output_schema = if schema.returns.is_empty() {
+                None
+            } else {
+                Some(schema.to_mcp_output_schema(registry)?)
+            };
+
+            let index = tools.len();
+            if let Some(prev) = by_name.insert(name.clone(), index) {
+                let prev: &McpTool = &tools[prev];
+                eyre::bail!(
+                    "duplicate MCP tool name {name} (endpoint codes {} and {})",
+                    prev.method_code,
+                    schema.code
+                );
+            }
+            tools.push(McpTool {
+                name,
+                description,
+                input_schema,
+                output_schema,
+                method_code: schema.code,
+                allowed_roles: endpoint.allowed_roles.clone(),
+                streaming,
+            });
+        }
+
+        Ok(Self {
+            tools,
+            by_name,
+            info,
+            protocol_version: MCP_PROTOCOL_VERSION,
+        })
+    }
+
+    fn initialize_result(&self) -> Value {
+        json!({
+            "protocolVersion": self.protocol_version,
+            "capabilities": { "tools": {} },
+            "serverInfo": { "name": self.info.name, "version": self.info.version },
+        })
+    }
+
+    fn tools_list_result(&self, roles: &[u32]) -> Value {
+        let tools: Vec<Value> = self
+            .tools
+            .iter()
+            .filter(|tool| roles_allowed(roles, &tool.allowed_roles))
+            .map(McpTool::to_list_entry)
+            .collect();
+        json!({ "tools": tools })
+    }
+
+    /// Routes a parsed JSON-RPC request to an [`McpAction`].
+    ///
+    /// `roles` are the connection's current roles; `tools/list` is filtered by
+    /// them and `tools/call` on a forbidden or unknown tool uniformly reports
+    /// "unknown tool" (so unauthorized callers cannot probe for existence).
+    pub fn route(&self, req: JsonRpcRequest, roles: &[u32]) -> McpAction {
+        match req.method.as_str() {
+            "initialize" => McpAction::Respond(jsonrpc_result(&req.id, self.initialize_result())),
+            "ping" => McpAction::Respond(jsonrpc_result(&req.id, json!({}))),
+            method if method.starts_with("notifications/") => McpAction::Ignore,
+            "tools/list" => {
+                McpAction::Respond(jsonrpc_result(&req.id, self.tools_list_result(roles)))
+            }
+            "tools/call" => self.route_tool_call(req, roles),
+            _ if req.is_notification() => McpAction::Ignore,
+            other => McpAction::Respond(jsonrpc_error(
+                &req.id,
+                JsonRpcError::new(METHOD_NOT_FOUND, format!("Method not found: {other}")),
+            )),
+        }
+    }
+
+    fn route_tool_call(&self, req: JsonRpcRequest, roles: &[u32]) -> McpAction {
+        let params = req.params.unwrap_or(Value::Null);
+        let Some(name) = params.get("name").and_then(Value::as_str) else {
+            return McpAction::Respond(jsonrpc_error(
+                &req.id,
+                JsonRpcError::new(INVALID_PARAMS, "tools/call requires a string `name` param"),
+            ));
+        };
+
+        let tool = self.by_name.get(name).map(|&i| &self.tools[i]);
+        let allowed = tool.is_some_and(|t| roles_allowed(roles, &t.allowed_roles));
+        let (Some(tool), true) = (tool, allowed) else {
+            return McpAction::Respond(jsonrpc_error(
+                &req.id,
+                JsonRpcError::new(INVALID_PARAMS, format!("Unknown tool: {name}")),
+            ));
+        };
+
+        let arguments = params
+            .get("arguments")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+
+        McpAction::ToolCall {
+            id: req.id,
+            method_code: tool.method_code,
+            arguments,
+        }
+    }
+}
+
+/// Same semantics as the legacy role check: allowed iff both sets are
+/// non-empty and intersect.
+fn roles_allowed(actual_roles: &[u32], allowed_roles: &HashSet<u32>) -> bool {
+    if allowed_roles.is_empty() || actual_roles.is_empty() {
+        return false;
+    }
+    actual_roles.iter().any(|role| allowed_roles.contains(role))
+}
+
+/// Per-call MCP context threaded through handler dispatch so the response can
+/// be encoded as a `tools/call` result addressed to the originating id.
+#[derive(Debug, Clone)]
+pub struct McpCallCtx {
+    pub id: Option<JsonRpcId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::libs::handler::RequestHandlerErased;
+    use crate::libs::toolbox::{ArcToolbox, RequestContext};
+    use crate::model::{EndpointSchema, Field, Type};
+    use async_trait::async_trait;
+    use std::sync::Arc;
+
+    struct NoopHandler;
+    #[async_trait(?Send)]
+    impl RequestHandlerErased for NoopHandler {
+        async fn handle(&self, _toolbox: &ArcToolbox, _ctx: RequestContext, _req: Value) {}
+    }
+
+    fn endpoint(name: &str, code: u32, roles: &[u32]) -> WsEndpoint {
+        let schema = EndpointSchema::new(
+            name,
+            code,
+            vec![Field::new("user_id", Type::Int64)],
+            vec![Field::new("ok", Type::Boolean)],
+        )
+        .with_description(format!("{name} endpoint"));
+        WsEndpoint {
+            schema,
+            handler: Arc::new(NoopHandler),
+            allowed_roles: roles.iter().cloned().collect(),
+        }
+    }
+
+    fn state() -> McpState {
+        let mut handlers = HashMap::new();
+        handlers.insert(10020, endpoint("UserListSymbols", 10020, &[1, 2]));
+        handlers.insert(10030, endpoint("AdminBanUser", 10030, &[9]));
+        McpState::build(
+            &handlers,
+            &TypeRegistry::new(),
+            McpServerInfo {
+                name: "test-server".into(),
+                version: "1.0.0".into(),
+            },
+        )
+        .unwrap()
+    }
+
+    fn parse(payload: &str) -> JsonRpcRequest {
+        try_parse_jsonrpc(payload).unwrap().unwrap()
+    }
+
+    #[test]
+    fn detection_ignores_legacy_and_non_json() {
+        assert!(try_parse_jsonrpc(r#"{"method":10020,"seq":1,"params":{}}"#).is_none());
+        assert!(try_parse_jsonrpc("not json").is_none());
+        assert!(try_parse_jsonrpc(r#"{"jsonrpc":"1.0","method":"x"}"#).is_none());
+        assert!(try_parse_jsonrpc(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#).is_some());
+    }
+
+    #[test]
+    fn malformed_jsonrpc_yields_error_frame() {
+        // Declares jsonrpc 2.0 but method is missing.
+        let result = try_parse_jsonrpc(r#"{"jsonrpc":"2.0","id":1}"#).unwrap();
+        let err = result.unwrap_err();
+        assert_eq!(err["error"]["code"], json!(INVALID_REQUEST));
+        assert_eq!(err["id"], Value::Null);
+    }
+
+    #[test]
+    fn id_round_trip() {
+        let req = parse(r#"{"jsonrpc":"2.0","id":"abc","method":"ping"}"#);
+        assert_eq!(req.id, Some(JsonRpcId::Str("abc".into())));
+        let req = parse(r#"{"jsonrpc":"2.0","id":7,"method":"ping"}"#);
+        assert_eq!(req.id, Some(JsonRpcId::Num(7)));
+        let req = parse(r#"{"jsonrpc":"2.0","method":"ping"}"#);
+        assert!(req.is_notification());
+        let req = parse(r#"{"jsonrpc":"2.0","id":null,"method":"ping"}"#);
+        assert!(req.is_notification());
+    }
+
+    #[test]
+    fn error_code_mapping() {
+        let err = error_code_to_jsonrpc(ErrorCode::BAD_REQUEST, json!({}));
+        assert_eq!(err.code, INVALID_PARAMS);
+        let err = error_code_to_jsonrpc(ErrorCode::NOT_IMPLEMENTED, json!({}));
+        assert_eq!(err.code, METHOD_NOT_FOUND);
+        let err = error_code_to_jsonrpc(ErrorCode::INTERNAL_ERROR, json!({}));
+        assert_eq!(err.code, INTERNAL_ERROR);
+        // Non-reserved codes pass through as positive app codes.
+        let err = error_code_to_jsonrpc(ErrorCode::FORBIDDEN, json!({ "message": "no" }));
+        assert_eq!(err.code, 100403);
+        let data = err.data.unwrap();
+        assert_eq!(data["kind"], json!("Forbidden"));
+        assert_eq!(data["appCode"], json!(100403));
+        assert_eq!(data["message"], json!("no"));
+    }
+
+    #[test]
+    fn initialize_golden() {
+        let state = state();
+        let req = parse(r#"{"jsonrpc":"2.0","id":0,"method":"initialize","params":{}}"#);
+        let McpAction::Respond(resp) = state.route(req, &[]) else {
+            panic!("expected response");
+        };
+        assert_eq!(
+            resp,
+            json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": {
+                    "protocolVersion": MCP_PROTOCOL_VERSION,
+                    "capabilities": { "tools": {} },
+                    "serverInfo": { "name": "test-server", "version": "1.0.0" },
+                },
+            })
+        );
+    }
+
+    #[test]
+    fn tools_list_filters_by_role() {
+        let state = state();
+        let req = parse(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+        let McpAction::Respond(resp) = state.route(req, &[1]) else {
+            panic!("expected response");
+        };
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], json!("user_list_symbols"));
+        assert_eq!(tools[0]["description"], json!("UserListSymbols endpoint"));
+        assert_eq!(tools[0]["inputSchema"]["required"], json!(["userId"]));
+        assert!(tools[0]["outputSchema"].is_object());
+
+        // No roles → empty list.
+        let req = parse(r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#);
+        let McpAction::Respond(resp) = state.route(req, &[]) else {
+            panic!("expected response");
+        };
+        assert_eq!(resp["result"]["tools"], json!([]));
+    }
+
+    #[test]
+    fn tools_call_routes_to_handler() {
+        let state = state();
+        let req = parse(
+            r#"{"jsonrpc":"2.0","id":5,"method":"tools/call",
+               "params":{"name":"user_list_symbols","arguments":{"userId":1}}}"#,
+        );
+        let McpAction::ToolCall {
+            id,
+            method_code,
+            arguments,
+        } = state.route(req, &[1])
+        else {
+            panic!("expected tool call");
+        };
+        assert_eq!(id, Some(JsonRpcId::Num(5)));
+        assert_eq!(method_code, 10020);
+        assert_eq!(arguments, json!({ "userId": 1 }));
+    }
+
+    #[test]
+    fn tools_call_unknown_and_forbidden_are_uniform() {
+        let state = state();
+        let unknown =
+            parse(r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"nope"}}"#);
+        let McpAction::Respond(unknown) = state.route(unknown, &[1]) else {
+            panic!("expected response");
+        };
+        // admin_ban_user exists but requires role 9; caller has role 1.
+        let forbidden = parse(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"admin_ban_user"}}"#,
+        );
+        let McpAction::Respond(forbidden) = state.route(forbidden, &[1]) else {
+            panic!("expected response");
+        };
+        assert_eq!(unknown["error"]["code"], forbidden["error"]["code"]);
+        assert_eq!(unknown["error"]["code"], json!(INVALID_PARAMS));
+        // Same shape modulo the tool name — no existence oracle.
+        assert!(
+            forbidden["error"]["message"]
+                .as_str()
+                .unwrap()
+                .starts_with("Unknown tool")
+        );
+    }
+
+    #[test]
+    fn notifications_are_ignored() {
+        let state = state();
+        let req = parse(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#);
+        assert!(matches!(state.route(req, &[1]), McpAction::Ignore));
+        // Unknown method as a notification → still no response.
+        let req = parse(r#"{"jsonrpc":"2.0","method":"bogus"}"#);
+        assert!(matches!(state.route(req, &[1]), McpAction::Ignore));
+        // Unknown method with an id → METHOD_NOT_FOUND.
+        let req = parse(r#"{"jsonrpc":"2.0","id":1,"method":"bogus"}"#);
+        let McpAction::Respond(resp) = state.route(req, &[1]) else {
+            panic!("expected response");
+        };
+        assert_eq!(resp["error"]["code"], json!(METHOD_NOT_FOUND));
+    }
+
+    #[test]
+    fn tool_result_encoding() {
+        let ok = encode_tool_result(&json!({ "ok": true }));
+        assert_eq!(ok["isError"], json!(false));
+        assert_eq!(ok["structuredContent"], json!({ "ok": true }));
+        assert_eq!(ok["content"][0]["type"], json!("text"));
+
+        let err = encode_tool_error(
+            ErrorCode::CONFLICT,
+            &json!({ "kind": "UsernameTaken", "message": "username taken" }),
+        );
+        assert_eq!(err["isError"], json!(true));
+        assert_eq!(err["content"][0]["text"], json!("username taken"));
+        assert_eq!(err["structuredContent"]["error"]["kind"], json!("Conflict"));
+    }
+
+    #[test]
+    fn duplicate_tool_names_rejected() {
+        let mut handlers = HashMap::new();
+        // Same name, different codes → same snake_case tool name.
+        handlers.insert(1, endpoint("UserGetInfo", 1, &[1]));
+        handlers.insert(2, endpoint("UserGetInfo", 2, &[1]));
+        let result = McpState::build(
+            &handlers,
+            &TypeRegistry::new(),
+            McpServerInfo {
+                name: "x".into(),
+                version: "0".into(),
+            },
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn streaming_endpoints_are_annotated() {
+        let mut handlers = HashMap::new();
+        let mut ep = endpoint("PriceWatch", 1, &[1]);
+        ep.schema.stream_response = Some(Type::Float64);
+        handlers.insert(1, ep);
+        let state = McpState::build(
+            &handlers,
+            &TypeRegistry::new(),
+            McpServerInfo {
+                name: "x".into(),
+                version: "0".into(),
+            },
+        )
+        .unwrap();
+        assert!(state.tools[0].streaming);
+        assert!(
+            state.tools[0]
+                .description
+                .contains("not delivered over MCP")
+        );
+    }
+}

--- a/src/libs/ws/server.rs
+++ b/src/libs/ws/server.rs
@@ -20,13 +20,14 @@ use crate::libs::utils::{get_conn_id, get_log_id};
 use crate::libs::ws::HyperTungsteniteUpgrader;
 #[cfg(any(feature = "ws", feature = "ws-wtx"))]
 use crate::libs::ws::TlsListener;
+use crate::libs::ws::mcp::{McpServerInfo, McpState};
 #[cfg(feature = "ws")]
 use crate::libs::ws::tungstenite::upgrader::create_ws_stream;
 use crate::libs::ws::{
     BoxedStream, ConnectionListener, TcpListener, WsClientSession, WsConnection, WsRequest,
     WsStream, WsUpgrader,
 };
-use crate::model::EndpointSchema;
+use crate::model::{EndpointSchema, TypeRegistry};
 
 use super::{AuthController, ConnectionId, SimpleAuthController, WebsocketStates, WsEndpoint};
 
@@ -38,6 +39,9 @@ pub struct WebsocketServer {
     pub config: WsServerConfig,
     pub cached_date: RwLock<String>,
     pub upgrader: Option<Arc<dyn WsUpgrader>>,
+    /// MCP surface state; `None` (the default) disables MCP entirely and the
+    /// server behaves exactly as before. See [`WebsocketServer::enable_mcp`].
+    pub mcp: Option<Arc<McpState>>,
 }
 
 impl WebsocketServer {
@@ -56,7 +60,24 @@ impl WebsocketServer {
             cached_date: RwLock::new(httpdate::fmt_http_date(std::time::SystemTime::now())),
             config,
             upgrader: default_upgrader(),
+            mcp: None,
         }
+    }
+
+    /// Enables the MCP (JSON-RPC 2.0) surface on this server.
+    ///
+    /// Call after all `add_handler()` calls and before `listen()`: tool
+    /// metadata is built once from the handlers registered so far. Fails on
+    /// unresolved type references or duplicate tool names.
+    pub fn enable_mcp(&mut self, registry: &TypeRegistry, info: McpServerInfo) -> Result<()> {
+        let state = McpState::build(&self.handlers, registry, info)?;
+        debug!(
+            ws_server = true,
+            "MCP enabled with {} tools",
+            state.tools.len()
+        );
+        self.mcp = Some(Arc::new(state));
+        Ok(())
     }
     pub fn set_auth_controller(&mut self, controller: impl AuthController + 'static) {
         self.auth_controller = Arc::new(controller);

--- a/src/libs/ws/session.rs
+++ b/src/libs/ws/session.rs
@@ -9,6 +9,9 @@ use crate::libs::ws::WsMessage as Message;
 use crate::libs::error_code::ErrorCode;
 use crate::libs::toolbox::{RequestContext, TOOLBOX};
 
+use super::mcp::{
+    self, JsonRpcError, JsonRpcId, JsonRpcRequest, McpAction, McpCallCtx, McpState, jsonrpc_error,
+};
 use super::{
     StreamError, WebsocketServer, WsConnection, WsRequestValue, WsResponseError, WsResponseValue,
     WsStream,
@@ -57,6 +60,22 @@ impl WsClientSession {
     fn handle_message(&mut self, msg: Message) -> Result<bool> {
         let addr = &self.conn_info.address;
         let mut context = RequestContext::from_conn(&self.conn_info);
+
+        // MCP: route JSON-RPC 2.0 frames to the MCP adapter when enabled.
+        // Detection is unambiguous: legacy frames ({method: u32, seq, params})
+        // can never carry a top-level "jsonrpc": "2.0" member.
+        if let Some(mcp) = &self.server.mcp {
+            let payload = match &msg {
+                Message::Text(t) => Some(t.as_str()),
+                Message::Binary(b) => std::str::from_utf8(b).ok(),
+                _ => None,
+            };
+            if let Some(frame) = payload.and_then(mcp::try_parse_jsonrpc) {
+                let mcp = Arc::clone(mcp);
+                self.handle_mcp_frame(mcp, frame, context);
+                return Ok(true);
+            }
+        }
 
         #[allow(unreachable_patterns)]
         let obj: Result<WsRequestValue, _> = match msg {
@@ -153,6 +172,76 @@ impl WsClientSession {
         });
 
         Ok(true)
+    }
+
+    /// Handles one parsed JSON-RPC frame: lifecycle methods are answered
+    /// inline from [`McpState`]; `tools/call` dispatches to the endpoint's
+    /// request handler via [`RequestHandlerErased::handle_mcp`].
+    ///
+    /// [`RequestHandlerErased::handle_mcp`]: crate::libs::handler::RequestHandlerErased::handle_mcp
+    fn handle_mcp_frame(
+        &mut self,
+        mcp: Arc<McpState>,
+        frame: Result<JsonRpcRequest, serde_json::Value>,
+        mut context: RequestContext,
+    ) {
+        let conn_id = context.connection_id;
+        let req = match frame {
+            Ok(req) => req,
+            Err(error_frame) => {
+                self.server
+                    .toolbox
+                    .send_raw(conn_id, error_frame.to_string());
+                return;
+            }
+        };
+
+        context.user_id = self.conn_info.get_user_id();
+        context.roles = self.conn_info.get_roles();
+
+        match mcp.route(req, &context.roles) {
+            McpAction::Respond(frame) => {
+                self.server.toolbox.send_raw(conn_id, frame.to_string());
+            }
+            McpAction::Ignore => {}
+            McpAction::ToolCall {
+                id,
+                method_code,
+                arguments,
+            } => {
+                context.method = method_code;
+                // Numeric ids that fit u32 double as the legacy seq for logging.
+                if let Some(JsonRpcId::Num(n)) = &id
+                    && let Ok(seq) = u32::try_from(*n)
+                {
+                    context.seq = seq;
+                }
+
+                let Some(endpoint) = self.server.handlers.get(&method_code) else {
+                    // Unreachable in practice: McpState is built from handlers.
+                    self.server.toolbox.send_raw(
+                        conn_id,
+                        jsonrpc_error(
+                            &id,
+                            JsonRpcError::new(mcp::METHOD_NOT_FOUND, "Method not found"),
+                        )
+                        .to_string(),
+                    );
+                    return;
+                };
+
+                let handler = endpoint.handler.clone();
+                let toolbox = self.server.toolbox.clone();
+                tokio::task::spawn_local(async move {
+                    TOOLBOX
+                        .scope(
+                            toolbox.clone(),
+                            handler.handle_mcp(&toolbox, context, McpCallCtx { id }, arguments),
+                        )
+                        .await;
+                });
+            }
+        }
     }
 
     async fn run_loop(&mut self) -> Result<()> {

--- a/src/libs/ws/toolbox.rs
+++ b/src/libs/ws/toolbox.rs
@@ -131,15 +131,19 @@ impl RequestContext {
 
 type SendFn = dyn Fn(ConnectionId, WsResponseValue) -> bool + Send + Sync;
 type SendFnArc = Arc<SendFn>;
+type SendRawFn = dyn Fn(ConnectionId, String) -> bool + Send + Sync;
+type SendRawFnArc = Arc<SendRawFn>;
 
 pub struct Toolbox {
     pub send_msg: OnceLock<SendFnArc>,
+    pub send_raw_msg: OnceLock<SendRawFnArc>,
 }
 pub type ArcToolbox = Arc<Toolbox>;
 impl Toolbox {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             send_msg: OnceLock::new(),
+            send_raw_msg: OnceLock::new(),
         })
     }
 
@@ -149,6 +153,7 @@ impl Toolbox {
         oneshot: bool,
         drop_on_buffer_full: bool,
     ) {
+        let raw_states = Arc::clone(&states);
         let send_fn: SendFnArc = Arc::new(move |conn_id, msg| {
             let state = if let Some(state) = states.get(&conn_id) {
                 state
@@ -170,6 +175,23 @@ impl Toolbox {
                 "set_ws_states called twice — ignoring second call"
             );
         }
+        // Pre-serialized frames (JSON-RPC/MCP responses) bypass WsResponseValue.
+        let send_raw_fn: SendRawFnArc = Arc::new(move |conn_id, serialized| {
+            let state = if let Some(state) = raw_states.get(&conn_id) {
+                state
+            } else {
+                return false;
+            };
+            Self::send_serialized_ws_msg(
+                &state.message_queue,
+                serialized,
+                oneshot,
+                conn_id,
+                drop_on_buffer_full,
+            );
+            true
+        });
+        let _ = self.send_raw_msg.set(send_raw_fn);
     }
 
     pub fn send_ws_msg(
@@ -186,6 +208,16 @@ impl Toolbox {
                 return;
             }
         };
+        Self::send_serialized_ws_msg(sender, serialized, oneshot, conn_id, drop_on_full)
+    }
+
+    pub fn send_serialized_ws_msg(
+        sender: &tokio::sync::mpsc::Sender<Message>,
+        serialized: String,
+        oneshot: bool,
+        conn_id: ConnectionId,
+        drop_on_full: bool,
+    ) {
         match sender.try_send(serialized.into()) {
             Ok(()) => {}
             Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {
@@ -211,6 +243,13 @@ impl Toolbox {
     pub fn send(&self, conn_id: ConnectionId, resp: WsResponseValue) -> bool {
         match self.send_msg.get() {
             Some(f) => f(conn_id, resp),
+            None => false,
+        }
+    }
+    /// Sends a pre-serialized frame (e.g. a JSON-RPC/MCP response) as-is.
+    pub fn send_raw(&self, conn_id: ConnectionId, serialized: String) -> bool {
+        match self.send_raw_msg.get() {
+            Some(f) => f(conn_id, serialized),
             None => false,
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,10 @@
 pub mod endpoint;
+pub mod json_schema;
 pub mod pg_func;
 pub mod service;
 pub mod types;
 pub use endpoint::*;
+pub use json_schema::*;
 pub use pg_func::*;
 pub use service::*;
 pub use types::*;

--- a/src/model/json_schema.rs
+++ b/src/model/json_schema.rs
@@ -1,0 +1,545 @@
+//! Conversion of the endpoint [`Type`] model into JSON Schema, as required by
+//! MCP (Model Context Protocol) tool definitions (`inputSchema` / `outputSchema`).
+//!
+//! The conversion is a pure function over [`Type`]; `StructRef`/`EnumRef`/
+//! `StructTable` references are resolved through a caller-provided
+//! [`TypeRegistry`] and emitted as `$ref` entries under `$defs`.
+
+use std::collections::BTreeMap;
+
+use convert_case::{Case, Casing};
+use eyre::{Result, bail};
+use serde_json::{Value, json};
+
+use crate::model::endpoint::EndpointSchema;
+use crate::model::types::{Field, Type};
+
+/// Name → [`Type`] map used to resolve `StructRef`, `EnumRef` and
+/// `StructTable` while converting to JSON Schema.
+///
+/// Built by the caller (a server at startup, or `endpoint-gen`) from the known
+/// struct and enum definitions.
+#[derive(Debug, Default, Clone)]
+pub struct TypeRegistry {
+    structs: BTreeMap<String, Type>,
+    enums: BTreeMap<String, Type>,
+}
+
+impl TypeRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Indexes `Struct` and `Enum` definitions found in `ty`, recursing into
+    /// struct fields and container types so nested definitions are captured.
+    pub fn add(&mut self, ty: &Type) {
+        match ty {
+            Type::Struct { name, fields } => {
+                self.structs.insert(name.clone(), ty.clone());
+                for field in fields {
+                    self.add(&field.ty);
+                }
+            }
+            Type::Enum { name, .. } => {
+                self.enums.insert(name.clone(), ty.clone());
+            }
+            Type::Vec(inner) | Type::Optional(inner) => self.add(inner),
+            _ => {}
+        }
+    }
+
+    /// Indexes every type in `tys`. See [`TypeRegistry::add`].
+    pub fn add_all<'a>(&mut self, tys: impl IntoIterator<Item = &'a Type>) {
+        for ty in tys {
+            self.add(ty);
+        }
+    }
+
+    /// Indexes all types referenced by an endpoint's parameters, returns and
+    /// stream response.
+    pub fn add_endpoint(&mut self, schema: &EndpointSchema) {
+        self.add_all(schema.parameters.iter().map(|f| &f.ty));
+        self.add_all(schema.returns.iter().map(|f| &f.ty));
+        if let Some(stream) = &schema.stream_response {
+            self.add(stream);
+        }
+    }
+
+    pub fn get_struct(&self, name: &str) -> Option<&Type> {
+        self.structs.get(name)
+    }
+
+    pub fn get_enum(&self, name: &str) -> Option<&Type> {
+        self.enums.get(name)
+    }
+}
+
+/// Definition name used for `$defs`/`$ref`. Enums keep their optional `Enum`
+/// prefix (mirrors `prefixed_name` handling in generated Rust code).
+fn enum_def_name(name: &str, prefixed_name: bool) -> String {
+    if prefixed_name {
+        format!("Enum{}", name.to_case(Case::Pascal))
+    } else {
+        name.to_case(Case::Pascal)
+    }
+}
+
+fn struct_def_name(name: &str) -> String {
+    name.to_case(Case::Pascal)
+}
+
+fn ref_to(def_name: &str) -> Value {
+    json!({ "$ref": format!("#/$defs/{def_name}") })
+}
+
+/// Builds an object schema over `fields`, in camelCase (matching the
+/// `#[serde(rename_all = "camelCase")]` on generated structs). Fields whose
+/// type is `Optional` are excluded from `required`.
+fn fields_to_object_schema(
+    fields: &[Field],
+    registry: &TypeRegistry,
+    defs: &mut BTreeMap<String, Value>,
+) -> Result<Value> {
+    let mut properties = serde_json::Map::new();
+    let mut required = Vec::new();
+
+    for field in fields {
+        let key = field.name.to_case(Case::Camel);
+        let mut schema = match &field.ty {
+            // Unwrap Optional at the field level: the field is simply not required.
+            Type::Optional(inner) => inner.to_json_schema(registry, defs)?,
+            other => {
+                required.push(Value::String(key.clone()));
+                other.to_json_schema(registry, defs)?
+            }
+        };
+        if !field.description.is_empty()
+            && let Value::Object(map) = &mut schema
+        {
+            map.entry("description")
+                .or_insert_with(|| Value::String(field.description.clone()));
+        }
+        properties.insert(key, schema);
+    }
+
+    let mut obj = serde_json::Map::new();
+    obj.insert("type".into(), "object".into());
+    obj.insert("properties".into(), Value::Object(properties));
+    obj.insert("required".into(), Value::Array(required));
+    obj.insert("additionalProperties".into(), Value::Bool(false));
+    Ok(Value::Object(obj))
+}
+
+fn enum_to_schema(name: &str, variants: &[crate::model::types::EnumVariant]) -> Value {
+    let one_of: Vec<Value> = variants
+        .iter()
+        .map(|v| {
+            let mut entry = serde_json::Map::new();
+            entry.insert("const".into(), json!(v.value));
+            entry.insert("title".into(), Value::String(v.name.clone()));
+            if !v.description.is_empty() {
+                entry.insert("description".into(), Value::String(v.description.clone()));
+            }
+            Value::Object(entry)
+        })
+        .collect();
+    json!({
+        "type": "integer",
+        "title": name,
+        "oneOf": one_of,
+    })
+}
+
+impl Type {
+    /// Converts this type to a JSON Schema fragment.
+    ///
+    /// `Struct`/`Enum` definitions (inline or by reference) are recorded in
+    /// `defs` and referenced via `$ref` so shared definitions are emitted once.
+    /// Returns an error for `StructRef`/`EnumRef`/`StructTable` names that are
+    /// not present in `registry` — callers should fail at startup rather than
+    /// emit a schema with dangling references.
+    pub fn to_json_schema(
+        &self,
+        registry: &TypeRegistry,
+        defs: &mut BTreeMap<String, Value>,
+    ) -> Result<Value> {
+        Ok(match self {
+            Type::UInt32 => json!({ "type": "integer", "minimum": 0, "maximum": u32::MAX }),
+            Type::Int32 => json!({ "type": "integer", "minimum": i32::MIN, "maximum": i32::MAX }),
+            Type::Int64 => json!({ "type": "integer" }),
+            Type::TimeStampMs => {
+                json!({ "type": "integer", "description": "Unix timestamp in milliseconds" })
+            }
+            Type::Float64 => json!({ "type": "number" }),
+            Type::Boolean => json!({ "type": "boolean" }),
+            Type::String => json!({ "type": "string" }),
+            Type::Bytea => json!({ "type": "string", "contentEncoding": "base64" }),
+            Type::UUID => json!({ "type": "string", "format": "uuid" }),
+            Type::NanoId { len } => json!({
+                "type": "string",
+                "minLength": len,
+                "maxLength": len,
+                "pattern": "^[0-9A-Za-z]+$",
+            }),
+            // Both IPv4 and IPv6 are accepted on the wire, so no single JSON
+            // Schema `format` applies.
+            Type::IpAddr => json!({ "type": "string", "description": "IPv4 or IPv6 address" }),
+            Type::Object => json!({ "type": "object" }),
+            Type::Unit => json!({ "type": "null" }),
+            Type::BlockchainDecimal => {
+                json!({ "type": "string", "description": "Decimal number as string" })
+            }
+            Type::BlockchainAddress => {
+                json!({ "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" })
+            }
+            Type::BlockchainTransactionHash => {
+                json!({ "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" })
+            }
+            Type::Vec(inner) => {
+                json!({ "type": "array", "items": inner.to_json_schema(registry, defs)? })
+            }
+            Type::Optional(inner) => {
+                // Standalone Optional (not unwrapped by a parent object):
+                // nullable variant of the inner schema.
+                let inner = inner.to_json_schema(registry, defs)?;
+                json!({ "anyOf": [inner, { "type": "null" }] })
+            }
+            Type::Struct { name, fields } => {
+                let def_name = struct_def_name(name);
+                if !defs.contains_key(&def_name) {
+                    // Reserve the slot first so recursive references terminate.
+                    defs.insert(def_name.clone(), Value::Null);
+                    let schema = fields_to_object_schema(fields, registry, defs)?;
+                    defs.insert(def_name.clone(), schema);
+                }
+                ref_to(&def_name)
+            }
+            Type::StructRef(name) => {
+                let Some(ty) = registry.get_struct(name).cloned() else {
+                    bail!("unresolved StructRef: {name} (not present in TypeRegistry)");
+                };
+                ty.to_json_schema(registry, defs)?
+            }
+            Type::StructTable { struct_ref } => {
+                let Some(ty) = registry.get_struct(struct_ref).cloned() else {
+                    bail!("unresolved StructTable ref: {struct_ref} (not present in TypeRegistry)");
+                };
+                let items = ty.to_json_schema(registry, defs)?;
+                json!({ "type": "array", "items": items })
+            }
+            Type::Enum { name, variants } => {
+                let def_name = enum_def_name(name, false);
+                defs.entry(def_name.clone())
+                    .or_insert_with(|| enum_to_schema(&def_name, variants));
+                ref_to(&def_name)
+            }
+            Type::EnumRef {
+                name,
+                prefixed_name,
+            } => {
+                let Some(Type::Enum { variants, .. }) = registry.get_enum(name) else {
+                    bail!("unresolved EnumRef: {name} (not present in TypeRegistry)");
+                };
+                let def_name = enum_def_name(name, *prefixed_name);
+                if !defs.contains_key(&def_name) {
+                    let schema = enum_to_schema(&def_name, variants);
+                    defs.insert(def_name.clone(), schema);
+                }
+                ref_to(&def_name)
+            }
+        })
+    }
+}
+
+/// Attaches accumulated `$defs` to a root schema object, if any.
+fn attach_defs(mut root: Value, defs: BTreeMap<String, Value>) -> Value {
+    if !defs.is_empty()
+        && let Value::Object(map) = &mut root
+    {
+        map.insert("$defs".into(), json!(defs));
+    }
+    root
+}
+
+impl EndpointSchema {
+    /// MCP tool name for this endpoint: the endpoint name in snake_case
+    /// (e.g. `UserListSymbols` → `user_list_symbols`).
+    pub fn tool_name(&self) -> String {
+        self.name.to_case(Case::Snake)
+    }
+
+    /// MCP `inputSchema`: an object schema over `parameters`. Non-`Optional`
+    /// parameters are listed in `required`.
+    pub fn to_mcp_input_schema(&self, registry: &TypeRegistry) -> Result<Value> {
+        let mut defs = BTreeMap::new();
+        let root = fields_to_object_schema(&self.parameters, registry, &mut defs)?;
+        Ok(attach_defs(root, defs))
+    }
+
+    /// MCP `outputSchema`: an object schema over `returns`.
+    pub fn to_mcp_output_schema(&self, registry: &TypeRegistry) -> Result<Value> {
+        let mut defs = BTreeMap::new();
+        let root = fields_to_object_schema(&self.returns, registry, &mut defs)?;
+        Ok(attach_defs(root, defs))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::types::EnumVariant;
+
+    fn schema_of(ty: &Type) -> Value {
+        let registry = TypeRegistry::new();
+        let mut defs = BTreeMap::new();
+        let schema = ty.to_json_schema(&registry, &mut defs).unwrap();
+        attach_defs(schema, defs)
+    }
+
+    #[test]
+    fn primitives() {
+        assert_eq!(
+            schema_of(&Type::UInt32),
+            json!({ "type": "integer", "minimum": 0, "maximum": u32::MAX })
+        );
+        assert_eq!(
+            schema_of(&Type::Int32),
+            json!({ "type": "integer", "minimum": i32::MIN, "maximum": i32::MAX })
+        );
+        assert_eq!(schema_of(&Type::Int64), json!({ "type": "integer" }));
+        assert_eq!(schema_of(&Type::Float64), json!({ "type": "number" }));
+        assert_eq!(schema_of(&Type::Boolean), json!({ "type": "boolean" }));
+        assert_eq!(schema_of(&Type::String), json!({ "type": "string" }));
+        assert_eq!(schema_of(&Type::Object), json!({ "type": "object" }));
+        assert_eq!(schema_of(&Type::Unit), json!({ "type": "null" }));
+    }
+
+    #[test]
+    fn string_formats() {
+        assert_eq!(
+            schema_of(&Type::Bytea),
+            json!({ "type": "string", "contentEncoding": "base64" })
+        );
+        assert_eq!(
+            schema_of(&Type::UUID),
+            json!({ "type": "string", "format": "uuid" })
+        );
+        assert_eq!(
+            schema_of(&Type::NanoId { len: 21 }),
+            json!({
+                "type": "string",
+                "minLength": 21,
+                "maxLength": 21,
+                "pattern": "^[0-9A-Za-z]+$",
+            })
+        );
+        assert_eq!(
+            schema_of(&Type::BlockchainAddress),
+            json!({ "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" })
+        );
+        assert_eq!(
+            schema_of(&Type::BlockchainTransactionHash),
+            json!({ "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" })
+        );
+    }
+
+    #[test]
+    fn containers() {
+        assert_eq!(
+            schema_of(&Type::vec(Type::String)),
+            json!({ "type": "array", "items": { "type": "string" } })
+        );
+        assert_eq!(
+            schema_of(&Type::optional(Type::Int64)),
+            json!({ "anyOf": [{ "type": "integer" }, { "type": "null" }] })
+        );
+    }
+
+    #[test]
+    fn inline_struct_goes_to_defs() {
+        let ty = Type::struct_(
+            "UserInfo",
+            vec![
+                Field::new("user_id", Type::Int64),
+                Field::new("email", Type::optional(Type::String)),
+            ],
+        );
+        let schema = schema_of(&ty);
+        assert_eq!(schema["$ref"], json!("#/$defs/UserInfo"));
+        let def = &schema["$defs"]["UserInfo"];
+        assert_eq!(def["type"], json!("object"));
+        assert_eq!(def["properties"]["userId"]["type"], json!("integer"));
+        assert_eq!(def["properties"]["email"]["type"], json!("string"));
+        // Optional field is not required.
+        assert_eq!(def["required"], json!(["userId"]));
+        assert_eq!(def["additionalProperties"], json!(false));
+    }
+
+    #[test]
+    fn enum_schema() {
+        let ty = Type::enum_(
+            "role",
+            vec![
+                EnumVariant::new_with_description("Admin", "administrator", 1),
+                EnumVariant::new("User", 2),
+            ],
+        );
+        let schema = schema_of(&ty);
+        assert_eq!(schema["$ref"], json!("#/$defs/Role"));
+        let def = &schema["$defs"]["Role"];
+        assert_eq!(def["type"], json!("integer"));
+        assert_eq!(def["oneOf"][0]["const"], json!(1));
+        assert_eq!(def["oneOf"][0]["title"], json!("Admin"));
+        assert_eq!(def["oneOf"][0]["description"], json!("administrator"));
+        assert_eq!(def["oneOf"][1], json!({ "const": 2, "title": "User" }));
+    }
+
+    #[test]
+    fn struct_ref_resolves_through_registry() {
+        let user_info = Type::struct_("UserInfo", vec![Field::new("user_id", Type::Int64)]);
+        let mut registry = TypeRegistry::new();
+        registry.add(&user_info);
+
+        let mut defs = BTreeMap::new();
+        let schema = Type::struct_ref("UserInfo")
+            .to_json_schema(&registry, &mut defs)
+            .unwrap();
+        assert_eq!(schema, json!({ "$ref": "#/$defs/UserInfo" }));
+        assert!(defs.contains_key("UserInfo"));
+    }
+
+    #[test]
+    fn struct_table_resolves_to_array() {
+        let row = Type::struct_("Row", vec![Field::new("id", Type::Int64)]);
+        let mut registry = TypeRegistry::new();
+        registry.add(&row);
+
+        let mut defs = BTreeMap::new();
+        let schema = Type::struct_table("Row")
+            .to_json_schema(&registry, &mut defs)
+            .unwrap();
+        assert_eq!(
+            schema,
+            json!({ "type": "array", "items": { "$ref": "#/$defs/Row" } })
+        );
+    }
+
+    #[test]
+    fn unresolved_refs_error() {
+        let registry = TypeRegistry::new();
+        let mut defs = BTreeMap::new();
+        assert!(
+            Type::struct_ref("Missing")
+                .to_json_schema(&registry, &mut defs)
+                .is_err()
+        );
+        assert!(
+            Type::enum_ref("Missing", true)
+                .to_json_schema(&registry, &mut defs)
+                .is_err()
+        );
+        assert!(
+            Type::struct_table("Missing")
+                .to_json_schema(&registry, &mut defs)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn enum_ref_prefixed_naming() {
+        let role = Type::enum_("role", vec![EnumVariant::new("Admin", 1)]);
+        let mut registry = TypeRegistry::new();
+        registry.add(&role);
+
+        let mut defs = BTreeMap::new();
+        let schema = Type::enum_ref("role", true)
+            .to_json_schema(&registry, &mut defs)
+            .unwrap();
+        assert_eq!(schema, json!({ "$ref": "#/$defs/EnumRole" }));
+        assert!(defs.contains_key("EnumRole"));
+    }
+
+    #[test]
+    fn shared_defs_emitted_once() {
+        let user_info = Type::struct_("UserInfo", vec![Field::new("user_id", Type::Int64)]);
+        let outer = Type::struct_(
+            "Outer",
+            vec![
+                Field::new("a", user_info.clone()),
+                Field::new("b", user_info),
+            ],
+        );
+        let schema = schema_of(&outer);
+        let def = &schema["$defs"]["Outer"];
+        assert_eq!(
+            def["properties"]["a"],
+            json!({ "$ref": "#/$defs/UserInfo" })
+        );
+        assert_eq!(
+            def["properties"]["b"],
+            json!({ "$ref": "#/$defs/UserInfo" })
+        );
+        assert!(schema["$defs"]["UserInfo"].is_object());
+    }
+
+    #[test]
+    fn tool_name_is_snake_case() {
+        let schema = EndpointSchema::new("UserListSymbols", 10020, vec![], vec![]);
+        assert_eq!(schema.tool_name(), "user_list_symbols");
+    }
+
+    #[test]
+    fn endpoint_input_schema_golden() {
+        let endpoint = EndpointSchema::new(
+            "UserGetProfile",
+            10010,
+            vec![
+                Field::new("user_id", Type::Int64),
+                Field::new_with_description(
+                    "nickname",
+                    "Optional display name",
+                    Type::optional(Type::String),
+                ),
+            ],
+            vec![Field::new("profile", Type::struct_ref("UserProfile"))],
+        );
+
+        let profile = Type::struct_(
+            "UserProfile",
+            vec![
+                Field::new("user_id", Type::Int64),
+                Field::new("role", Type::enum_ref("role", true)),
+            ],
+        );
+        let role = Type::enum_("role", vec![EnumVariant::new("Admin", 1)]);
+        let mut registry = TypeRegistry::new();
+        registry.add(&profile);
+        registry.add(&role);
+
+        let input = endpoint.to_mcp_input_schema(&registry).unwrap();
+        assert_eq!(
+            input,
+            json!({
+                "type": "object",
+                "properties": {
+                    "userId": { "type": "integer" },
+                    "nickname": { "type": "string", "description": "Optional display name" },
+                },
+                "required": ["userId"],
+                "additionalProperties": false,
+            })
+        );
+
+        let output = endpoint.to_mcp_output_schema(&registry).unwrap();
+        assert_eq!(
+            output["properties"]["profile"],
+            json!({ "$ref": "#/$defs/UserProfile" })
+        );
+        assert_eq!(output["required"], json!(["profile"]));
+        assert_eq!(
+            output["$defs"]["UserProfile"]["properties"]["role"],
+            json!({ "$ref": "#/$defs/EnumRole" })
+        );
+        assert!(output["$defs"]["EnumRole"].is_object());
+    }
+}

--- a/src/model/types.rs
+++ b/src/model/types.rs
@@ -88,7 +88,9 @@ pub enum Type {
     String,
     Bytea,
     UUID,
-    NanoId { len: usize },
+    NanoId {
+        len: usize,
+    },
     IpAddr,
     Struct {
         name: String,


### PR DESCRIPTION
## Summary

PR 3 of 3 (stacked on #35). Wires the MCP surface into the server — **off by default** (`mcp: None`); with MCP disabled every touched path behaves exactly as before, and even with it enabled, legacy frames take the pre-existing path untouched. Both protocols work on the same connection.

The only edits to existing files (~80 lines total):
- **server.rs**: `WebsocketServer::mcp` field + `enable_mcp(registry, info)` — builds `McpState` from registered handlers, failing at startup on bad schemas
- **session.rs**: JSON-RPC frames routed to the MCP adapter; lifecycle methods answered inline, `tools/call` dispatched to the endpoint handler on the local task set
- **toolbox.rs**: `send_raw()` for pre-serialized frames (`send_ws_msg` split into serialize + `send_serialized_ws_msg`; behavior identical)
- **handler.rs**: `RequestHandlerErased::handle_mcp` with a default body (manual impls stay source-compatible); blanket impl deserializes like the legacy path (same `serde_path_to_error` diagnostics → `-32602`) and encodes success as MCP tool results, public errors as `isError: true` results, internal errors as `-32603` with `logId`

Also adds a **self-asserting end-to-end example** and README documentation:

```sh
cargo run --example mcp_echo --features ws-http1
```

## Test plan
- Example run verified live — 13/13 checks pass: `initialize` → `notifications/initialized` → `tools/list` → `tools/call`, invalid-params → `-32602`, and a legacy `{method, seq, params}` frame on the same connection returning the unchanged `{type: Immediate}` shape
- `cargo test --features ws` (55) and default-features (32) green; `cargo clippy --features ws-http1 --all-targets` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)