### PR TITLE
ci: fix invalid YAML that silently disabled the Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,8 +26,6 @@ jobs:
     - uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: "true"
-        add-job-id-key: "false"
-        add-rust-environment-hash-key: "false"
 
     - name: Install Rust
       uses: actions-rs/toolchain@v1
@@ -59,9 +57,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-            cache-on-failure: "true"
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
+          cache-on-failure: "true"
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1
@@ -85,9 +81,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-            cache-on-failure: "true"
-          add-job-id-key: "false"
-          add-rust-environment-hash-key: "false"
+          cache-on-failure: "true"
 
       - name: Install Rust
         uses: actions-rs/toolchain@v1


### PR DESCRIPTION
## Summary

Every `rust.yml` run has been failing in **0s** with *"This run likely failed because of a workflow file issue"* — since at least the v1.8.2 release commit (June 15), and it's also why the recent MCP PRs (#34–#36) reported **no checks at all**.

Root cause: invalid YAML indentation in the `clippy_check` and `format_check` jobs — `cache-on-failure` was indented deeper than its sibling keys under `with:`, so GitHub rejected the entire workflow file at parse time:

```yaml
      - uses: Swatinem/rust-cache@v2
        with:
            cache-on-failure: "true"        # 12 spaces
          add-job-id-key: "false"           # 10 spaces ← invalid
```

This PR normalizes the indentation and drops `add-job-id-key` / `add-rust-environment-hash-key`, which are not valid `rust-cache@v2` inputs anyway.

## Test plan
- YAML validated locally
- This PR's own checks running is itself the proof — first time the workflow parses in months. Note CI may surface real, previously-hidden failures on main; those are pre-existing and separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)