### PR TITLE
fix: repair feature-combination builds, clippy, and security audit now that CI runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
         run: cargo install cargo-all-features
 
       - name: Clippy check all feature combinations
-        run: cargo all-features clippy --all-targets --all-features -- -D warnings
+        run: cargo all-features clippy --all-targets -- -D warnings
 
   format_check:
 
@@ -101,3 +101,7 @@ jobs:
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # quick-xml DoS advisories: the fix requires quick-xml >=0.41, but the
+          # dev-dependency-only chain cert-provider -> rust-s3/aws-creds pins
+          # ^0.38. Re-evaluate when upstream releases with a newer quick-xml.
+          ignore: RUSTSEC-2026-0194,RUSTSEC-2026-0195

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -127,7 +127,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1410,7 +1410,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1643,11 +1643,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1657,11 +1655,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2460,7 +2460,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2838,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64",
  "byteorder",
@@ -2856,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -3028,14 +3028,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3163,6 +3164,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"
@@ -3505,7 +3515,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3573,7 +3583,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3944,7 +3954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4091,7 +4101,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4253,9 +4263,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4958,7 +4968,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,11 +219,6 @@ name = "ws_echo_server"
 path = "examples/ws-echo/main.rs"
 required-features = ["ws"]
 
-[[example]]
-name = "ws_echo_server_wtx"
-path = "examples/ws-echo/main.rs"
-required-features = ["ws-wtx"]
-
 [package.metadata.cargo-all-features]
 
 # Always include these features in combinations.
@@ -235,17 +230,8 @@ always_include_features = ["types"]
 denylist = [
     "full",           # full is redundant to include in the matrix
     "log_throttling", # log_throttling is currently not working
-]
-
-# ws and ws-wtx are mutually exclusive backends — skip permutations including both
-# (includes compound features that transitively enable ws)
-skip_feature_sets = [
-    ["ws", "ws-wtx"],
-    ["ws-http1", "ws-wtx"],
-    ["ws-tls12", "ws-wtx"],
-    ["ws", "ws-wtx-http2"],
-    ["ws-http1", "ws-wtx-http2"],
-    ["ws-tls12", "ws-wtx-http2"],
+    "ws-wtx",         # deprecated: contains a compile_error! directing users to `ws`
+    "ws-wtx-http2",   # deprecated: depends on ws-wtx
 ]
 
 # If your crate has a large number of optional dependencies, skip them for speed
@@ -259,7 +245,10 @@ skip_feature_sets = [
 # The maximum number of features to try at once. Does not count features from `always_include_features`.
 # This is useful for reducing the number of combinations run for a crate with a large amount of features,
 # since in most cases a bug just needs a small set of 2-3 features to reproduce.
-# max_combination_size = 4
+# With 11 matrix features the unbounded matrix is 2048 combinations (hours per CI
+# job); capping at 3 gives 232 combinations while still covering every pairwise
+# and most triple-feature interactions.
+max_combination_size = 3
 
 # Only include certain features in the build matrix
 #(incompatible with `denylist`, `skip_optional_dependencies`, and `extra_features`)

--- a/src/libs/log/error_aggregation.rs
+++ b/src/libs/log/error_aggregation.rs
@@ -57,6 +57,15 @@ pub struct ErrorAggregationConfig {
     pub normalize: bool, // Whether to normalize messages for deduplication
 }
 
+impl Default for ErrorAggregationConfig {
+    fn default() -> Self {
+        Self {
+            limit: 100,
+            normalize: true,
+        }
+    }
+}
+
 /// Internal storage representation
 #[derive(Debug)]
 struct ErrorStorage {
@@ -132,7 +141,7 @@ impl ErrorAggregationContainer {
         if let Some(mut cmp) = sort_by {
             entries.sort_by(|a, b| cmp(a, b));
         } else {
-            entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+            entries.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
         }
 
         entries.into_iter().skip(offset).take(limit).collect()
@@ -144,7 +153,7 @@ impl ErrorAggregationContainer {
         let map = storage.get_map();
 
         let mut stats: Vec<ErrorStats> = map.values().cloned().collect();
-        stats.sort_by(|a, b| b.last_seen.cmp(&a.last_seen));
+        stats.sort_by_key(|s| std::cmp::Reverse(s.last_seen));
         stats.into_iter().skip(offset).take(limit).collect()
     }
 

--- a/src/libs/ws/client.rs
+++ b/src/libs/ws/client.rs
@@ -53,8 +53,8 @@ pub struct WsConnectResponse {
 // ---------------------------------------------------------------------------
 
 enum WsStream {
-    H1(WebSocketStream<MaybeTlsStream<TcpStream>>),
-    H2(WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>),
+    H1(Box<WebSocketStream<MaybeTlsStream<TcpStream>>>),
+    H2(Box<WebSocketStream<TokioIo<hyper::upgrade::Upgraded>>>),
 }
 
 // ---------------------------------------------------------------------------
@@ -96,7 +96,7 @@ impl WsClient {
             .context("Failed to connect to endpoint")?;
         Ok((
             Self {
-                stream: WsStream::H1(ws_stream),
+                stream: WsStream::H1(Box::new(ws_stream)),
                 seq: 0,
             },
             response,
@@ -124,8 +124,8 @@ impl WsClient {
 
     async fn stream_close(&mut self) -> Result<()> {
         match &mut self.stream {
-            WsStream::H1(s) => s.close(None).await?,
-            WsStream::H2(s) => s.close(None).await?,
+            WsStream::H1(s) => s.as_mut().close(None).await?,
+            WsStream::H2(s) => s.as_mut().close(None).await?,
         }
         Ok(())
     }
@@ -385,7 +385,7 @@ async fn connect_h1(
 
     Ok((
         WsClient {
-            stream: WsStream::H1(ws_stream),
+            stream: WsStream::H1(Box::new(ws_stream)),
             seq: 0,
         },
         conn_resp,
@@ -543,7 +543,7 @@ where
 
     Ok((
         WsClient {
-            stream: WsStream::H2(ws),
+            stream: WsStream::H2(Box::new(ws)),
             seq: 0,
         },
         conn_resp,

--- a/src/libs/ws/server.rs
+++ b/src/libs/ws/server.rs
@@ -1,5 +1,7 @@
 use super::WsMessage as Message;
-use eyre::{ContextCompat, Result, bail, eyre};
+#[cfg(feature = "ws")]
+use eyre::eyre;
+use eyre::{ContextCompat, Result, bail};
 use itertools::Itertools;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -12,9 +14,11 @@ use tokio::sync::mpsc;
 use tokio::task::LocalSet;
 use tracing::*;
 
+#[cfg(feature = "ws")]
 use crate::libs::error_code::ErrorCode;
 use crate::libs::handler::{RequestHandler, RequestHandlerErased};
 use crate::libs::toolbox::{ArcToolbox, RequestContext, TOOLBOX, Toolbox};
+#[cfg(feature = "ws")]
 use crate::libs::utils::{get_conn_id, get_log_id};
 #[cfg(feature = "ws")]
 use crate::libs::ws::HyperTungsteniteUpgrader;
@@ -115,6 +119,7 @@ impl WebsocketServer {
         }
     }
 
+    #[cfg(feature = "ws")]
     async fn handle_ws_handshake_and_connection(
         self: Arc<Self>,
         addr: SocketAddr,
@@ -166,6 +171,19 @@ impl WebsocketServer {
         Ok(())
     }
 
+    #[cfg(not(feature = "ws"))]
+    async fn handle_ws_handshake_and_connection(
+        self: Arc<Self>,
+        _addr: SocketAddr,
+        _states: Arc<WebsocketStates>,
+        _stream: BoxedStream,
+    ) -> Result<()> {
+        bail!(
+            "WebSocket upgrades require a backend that can create WS streams (enable the `ws` feature)"
+        )
+    }
+
+    #[cfg(feature = "ws")]
     async fn post_upgrade_connection(
         self: Arc<Self>,
         addr: SocketAddr,

--- a/src/libs/ws/traits.rs
+++ b/src/libs/ws/traits.rs
@@ -52,6 +52,9 @@ pub trait WsStream: Unpin + Send {
 /// An upgrade event yielded by the upgrader.
 /// Contains the on_upgrade future and the negotiated protocol.
 pub struct UpgradeEvent {
+    /// Only present with a hyper-based backend (`ws` or `ws-client`), which is
+    /// what provides the `hyper` dependency.
+    #[cfg(any(feature = "ws", feature = "ws-client"))]
     pub on_upgrade: hyper::upgrade::OnUpgrade,
     pub protocol: String,
 }


### PR DESCRIPTION
## Summary

PR #37 fixed the workflow YAML so CI jobs actually execute — which surfaced that the jobs themselves fail on pre-existing issues (confirmed broken at v1.8.2 / 5a1ac6a). This PR makes all four jobs pass:

**Feature-gate fixes (real bugs)**
- `ws-core` without a backend didn't compile: `UpgradeEvent.on_upgrade` is hyper-typed but hyper is only provided by `ws`/`ws-client`; the field is now gated accordingly.
- Any combo without `ws` (including `ws-client` alone) didn't compile: the server's upgrade path called the `ws`-gated `create_ws_stream` unconditionally. It's now gated on `ws` with a bailing stub, mirroring the existing `listen_tls` pattern.

**Feature matrix (`[package.metadata.cargo-all-features]`)**
- `ws-wtx`/`ws-wtx-http2` contain a deliberate `compile_error!` ("deprecated, use `ws`") and can never build — they're now denylisted (superseding the pairwise `skip_feature_sets`), and the un-buildable `ws_echo_server_wtx` example target is removed. The deprecation guard itself is untouched and still fires for anyone enabling the features manually.
- Capped the matrix at `max_combination_size = 3`: the unbounded matrix is 2^11 = 2048 combinations (measured ~3.3s each just for `check` — hours per CI job, worse for test/clippy), which would re-break CI via the 6-hour job limit. 232 combinations still cover all pairwise and triple interactions; every bug fixed here reproduced with ≤2 features.

**Clippy (`-D warnings`, pre-existing failures)**
- `large_enum_variant` in the WS client: boxed both `WsStream` variants (boxing only H1 just flips which variant is oversized). `close(None)` needs `as_mut()` so it resolves to the inherent `WebSocketStream::close` instead of `SinkExt::close`.
- `unnecessary_sort_by` ×2 in error aggregation → `sort_by_key` with `Reverse`.
- `examples/mcp_echo.rs` used `Default::default()` for `ErrorAggregationConfig`, which had no `Default` impl — added one with the `{limit: 100, normalize: true}` values used everywhere else.

**Security audit**
- Bumped `postgres-protocol` → 0.6.12, `tokio-postgres` → 0.7.18, `quinn-proto` → 0.11.16 (lockfile-only, semver-compatible).
- The two quick-xml DoS advisories (RUSTSEC-2026-0194/0195) cannot be fixed: the patch is quick-xml ≥0.41, but even the latest `rust-s3` 0.37.2 / `aws-creds` 0.39.1 pin `^0.38` — and the chain is dev-dependency-only (`cert-provider` → `rust-s3`). They're ignored in the audit job with an explanatory comment; re-evaluate when upstream bumps.

**Workflow**
- The clippy job passed `--all-features` to each per-combination run, force-enabling the mutually exclusive `ws-wtx` (and its `compile_error!`) on every iteration — removed.

## Verification (local, cargo 1.97.0)

- `cargo check-all-features`: all 232 combinations pass
- `cargo clippy --all-targets -- -D warnings` on default, `full`, `ws`, `ws-core`, `ws-client`, `error_aggregation`, and the maximal non-wtx combo: clean
- `cargo test` on default (32 passed) and `full` (65 passed): green
- `cargo audit` with the two ignores: passes
- `cargo fmt --all -- --check`: clean
- `--features ws-wtx` still fails with the intended deprecation `compile_error!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)