### PR TITLE
fix: make security_audit pass (permissions, rustls-pemfile migration, anyhow bump)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,6 +96,12 @@ jobs:
 
   security_audit:
     runs-on: ubicloud-standard-2
+    permissions:
+      contents: read
+      # audit-check reports its findings as a check run; without this the
+      # report API call fails with "Resource not accessible by integration"
+      # and the job errors even when no vulnerabilities are found.
+      checks: write
     steps:
       - uses: actions/checkout@v4
       - uses: rustsec/audit-check@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ark-ff"
@@ -1352,7 +1352,6 @@ dependencies = [
  "rev_lines",
  "rust_decimal",
  "rustls",
- "rustls-pemfile",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ ws = [
     "dep:tokio-tungstenite",
     "dep:tokio-rustls",
     "dep:rustls",
-    "dep:rustls-pemfile",
     "dep:reqwest",
     "dep:hyper",
     "dep:hyper-util",
@@ -104,8 +103,7 @@ ws-wtx = [
     "dep:base64",
     "dep:tokio-rustls",
     "dep:rustls",
-    "dep:rustls-pemfile",
-    "rustls/tls12", 
+    "rustls/tls12",
     "tokio-rustls/tls12",
 ]
 ws-wtx-http2 = ["ws-wtx", "wtx/http2"]
@@ -142,7 +140,6 @@ tokio-tungstenite = { version = "0.29.0", default-features = false, features = [
     "connect",
 ], optional = true }
 tokio-rustls = { version = "0.26", optional = true, default-features = false, features = ["ring", "logging"] }
-rustls-pemfile = { version = "2.1", optional = true }
 rustls = { version = "0.23", optional = true, default-features = false, features = ["ring", "logging", "std"] }
 tokio = { version = "1.39", features = ["full"] }
 tokio-util = { version = "0.7", optional = true }

--- a/src/libs/ws/tls.rs
+++ b/src/libs/ws/tls.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::net::SocketAddr;
 use std::path::Path;
 use std::path::PathBuf;
@@ -10,7 +9,6 @@ use futures::future::BoxFuture;
 use rustls::pki_types::CertificateDer;
 use rustls::pki_types::PrivateKeyDer;
 use rustls::pki_types::pem::PemObject;
-use rustls_pemfile::certs;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::server::TlsStream;
 
@@ -89,12 +87,10 @@ fn load_certs<'a, T: AsRef<Path>>(
     let mut r_certs = vec![];
     for p in path {
         let p = p.as_ref();
-        let f = File::open(p).with_context(|| format!("Failed to open {}", p.display()))?;
-
-        let reader = &mut std::io::BufReader::new(f);
-        let certs_results = certs(reader);
-
-        let certs: Vec<CertificateDer> = certs_results.filter_map(|result| result.ok()).collect();
+        let certs: Vec<CertificateDer> = CertificateDer::pem_file_iter(p)
+            .with_context(|| format!("Failed to open {}", p.display()))?
+            .filter_map(|result| result.ok())
+            .collect();
 
         r_certs.extend(certs);
     }


### PR DESCRIPTION
## Summary

Follow-up to #38, which eliminated all audit *vulnerabilities* — yet the security_audit job on main still fails. Root cause: with zero vulnerabilities found, audit-check tries to report its 4 remaining *warnings* as a check run and dies on `Resource not accessible by integration` because the job has no `permissions:` block.

1. **rust.yml** — grant `security_audit` `checks: write` (+ `contents: read`) so the report call succeeds; warnings then no longer fail the job
2. **rustls-pemfile → rustls-pki-types** (RUSTSEC-2025-0134, unmaintained, was a *direct* dep): `load_certs` now uses `CertificateDer::pem_file_iter` — the same `PemObject` API the private-key path already used. Direct dependency removed from Cargo.toml (stays lockfile-only via the deprecated `ws-wtx`/wtx path)
3. **anyhow 1.0.102 → 1.0.103** (`cargo update`) — clears the unsound `downcast_mut` advisory (RUSTSEC-2026-0190)

Remaining warnings after this PR: `derivative` and `paste` (unmaintained, transitive via alloy-primitives etc.) and `rustls-pemfile` via deprecated wtx — all non-failing.

## Test plan
- `cargo test --features full`: 65 tests green; clippy `--features full --all-targets`: clean; fmt clean
- Runtime smoke test: `ws_echo_server` (TLS) generates a self-signed cert and successfully binds through the migrated `load_certs` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)